### PR TITLE
discover: fix sysfs end-of-partition calculation

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -172,7 +172,11 @@ func findDisks(disk, syspath string) (map[string][]partitionData, error) {
 			if err != nil {
 				return nil, err
 			}
-			end := size - start + 1
+			// sysfs reports `size` as the partition's length in sectors
+			// (not its last LBA), so the inclusive last sector is
+			// start + size - 1. The disk-image branch above uses the
+			// same formula.
+			end := start + size - 1
 			// read from uevent to get name
 			ueventPath := filepath.Join(sysClassBlockPath, candidate.Name(), name, "uevent")
 			ueventData, err := os.ReadFile(ueventPath)

--- a/discover_test.go
+++ b/discover_test.go
@@ -133,10 +133,16 @@ func TestFindDisks(t *testing.T) {
 		if pd.label != "foo" {
 			t.Errorf("pd.label = %q, want foo", pd.label)
 		}
-		// start and size in bytes (blockSize=512)
+		// start, size, and end in bytes (blockSize=512). End is the
+		// inclusive last byte of the partition, i.e.
+		// (start_sector + size_sectors - 1) * blockSize.
 		if pd.start != 2*512 || pd.size != 4*512 {
 			t.Errorf("(start,size) = (%d,%d), want (%d,%d)",
 				pd.start, pd.size, 2*512, 4*512)
+		}
+		expectedEnd := int64((2+4-1) * 512)
+		if pd.end != expectedEnd {
+			t.Errorf("pd.end = %d, want %d", pd.end, expectedEnd)
 		}
 	})
 	t.Run("single", func(t *testing.T) {


### PR DESCRIPTION
## Summary

The sysfs branch of `findDisks` (`discover.go:175`) computed each partition's last-byte position as `size - start + 1`. That's not the right formula for anything; the sysfs `size` attribute is the partition's length in sectors, so the inclusive last LBA is `start + size - 1`. The disk-image branch a few dozen lines up (`discover.go:78`) already uses the correct formula:

```go
end:    start + p.GetSize() - 1,
```

## Impact

`partitionData.end` flows into:

- `calculate.go:48`, `:53`, `:54`, `:63`, `:67`, `:69`, `:106`, `:131`, `:133`, `:134` — every free-space and grow-target computation in `calculateResizes`.
- `run_helpers.go:150` — the shrink-target end in `planResizes`.

So whenever partitionresizer runs against a real block device (which routes through sysfs) rather than a disk image (which routes through the GPT-table branch), the resize plan is computed against silently wrong partition geometry. The disk-image-only test fixtures (`testdata/disk.img`, `testdata/diskfull.img`) hid this from CI.

## Fix

One-line change: `end := size - start + 1` → `end := start + size - 1`, with a comment explaining the formula matches the disk-image branch.

Extend `TestFindDisks/all` to assert `pd.end` so this regression can't slip back through.

## Test plan

```
$ go test -run '^TestFindDisks$' ./...
=== RUN   TestFindDisks
--- PASS: TestFindDisks (0.01s)
ok  	github.com/diskfs/partitionresizer	0.014s
```

Signed-off-by: eriknordmark <erik@zededa.com>