### PR TITLE
resize: make interrupted resizes safe to resume

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,7 @@ jobs:
       - name: Create test tmp dir
         run: sudo mkdir /mnt/tmp && sudo chmod 1777 /mnt/tmp
       - name: test
-        run: TMPDIR=/mnt/tmp go test ./...
+        # 30m timeout: the restart-safety tests in resume_test.go run real
+        # end-to-end resizes (shrink + copy of a multi-GB fixture), which can
+        # exceed the default 10m. Use `-short` to skip them in a fast loop.
+        run: TMPDIR=/mnt/tmp go test -timeout 30m ./...

--- a/resize.go
+++ b/resize.go
@@ -55,23 +55,92 @@ func resize(d *disk.Disk, resizes []partitionResizeTarget, fixErrors, preserveNu
 		return err
 	}
 
-	// swap the partitions, specifically the labels, Type GUIDs, and UUIDs, as well as attributes flags
-	if err := swapPartitions(d, resizes); err != nil {
+	// finalize: in a single idempotent step, give each relocated target the
+	// original partition's identity (name, type GUID, partition GUID,
+	// attributes), set its partition number (the original number when
+	// preserveNumbers, otherwise the number it was created with), and remove the
+	// superseded original partition.
+	if err := updatePartitions(d, resizes, preserveNumbers); err != nil {
 		return err
 	}
 
-	// remove the old partitions, optionally renumbering the relocated partitions
-	// back to their original partition numbers
-	if preserveNumbers {
-		if err := removeAndRenumberPartitions(d, resizes); err != nil {
-			return err
+	return nil
+}
+
+// updatePartitions performs the final, idempotent phase of a resize. For each
+// relocated partition it gives the target the identity of its original (name,
+// type GUID, partition GUID, attributes), assigns the target's partition number
+// (the original number when preserveNumbers, otherwise the number it was created
+// with), and removes the now-superseded original -- all in a single partition
+// table write.
+//
+// It supersedes the swapPartitions + removePartitions/removeAndRenumberPartitions
+// sequence (still defined below but no longer called). Unlike the swap, it is idempotent:
+// it identifies partitions by their on-disk start offset -- the one identifier
+// that is stable across this phase, since names and numbers change -- sets the
+// desired final state directly rather than exchanging values, and treats an
+// already-removed original as a no-op. Re-running after an interruption
+// therefore converges instead of undoing a completed operation.
+func updatePartitions(d *disk.Disk, resizes []partitionResizeTarget, preserveNumbers bool) error {
+	tableRaw, err := d.GetPartitionTable()
+	if err != nil {
+		return err
+	}
+	table, ok := tableRaw.(*gpt.Table)
+	if !ok {
+		return fmt.Errorf("unsupported partition table type, only GPT is supported")
+	}
+	// Index active partitions by start sector. Start is the only identifier that
+	// does not change during this phase (names and numbers do), so it is the
+	// stable key for locating the target and the original on a re-run.
+	byStart := make(map[uint64]*gpt.Partition)
+	for _, p := range table.Partitions {
+		if p.Type == gpt.Unused {
+			continue
 		}
-	} else {
-		if err := removePartitions(d, resizes); err != nil {
-			return err
+		byStart[p.Start] = p
+	}
+	sectorSize := int64(table.LogicalSectorSize)
+	removeStart := make(map[uint64]bool)
+	for _, r := range resizes {
+		if r.original.start == r.target.start {
+			// shrunk in place: not relocated, so no identity move or removal
+			continue
+		}
+		targetStart := uint64(r.target.start / sectorSize)
+		originalStart := uint64(r.original.start / sectorSize)
+		target := byStart[targetStart]
+		if target == nil {
+			return fmt.Errorf("target partition for %s at start %d not found", r.original.label, r.target.start)
+		}
+		// Copy the original's identity onto the target, but only while the
+		// original is still present. Once a prior (interrupted) run has removed
+		// it, the target already carries the final identity and this is skipped.
+		if original := byStart[originalStart]; original != nil {
+			log.Printf("finalizing partition at start %d to identity of %s (partition %d); removing original", r.target.start, r.original.label, r.original.number)
+			target.Name = original.Name
+			target.Type = original.Type
+			target.GUID = original.GUID
+			target.Attributes = original.Attributes
+			removeStart[originalStart] = true
+		}
+		if preserveNumbers {
+			target.Index = r.original.number
 		}
 	}
-
+	if len(removeStart) > 0 {
+		kept := make([]*gpt.Partition, 0, len(table.Partitions))
+		for _, p := range table.Partitions {
+			if p.Type != gpt.Unused && removeStart[p.Start] {
+				continue
+			}
+			kept = append(kept, p)
+		}
+		table.Partitions = kept
+	}
+	if err := d.Partition(table); err != nil {
+		return fmt.Errorf("failed to write updated partition table: %v", err)
+	}
 	return nil
 }
 

--- a/resize.go
+++ b/resize.go
@@ -154,6 +154,14 @@ func copyFilesystems(d *disk.Disk, resizes []partitionResizeTarget) error {
 				return fmt.Errorf("failed to copy raw data for partition %s: %v", r.original.label, err)
 			}
 		case fs.Type() == filesystem.TypeExt4:
+			// On resume, the target may already hold a complete, matching copy
+			// from a prior run; in that case skip the reformat+recopy. CompareFS
+			// is a structural/content equality check against the source, not a
+			// filesystem integrity check.
+			if existing, eerr := d.GetFilesystem(r.target.number); eerr == nil && sync.CompareFS(fs, existing) == nil {
+				log.Printf("partition %d -> %d: target filesystem already matches source, skipping copy", r.original.number, r.target.number)
+				continue
+			}
 			newFS, err := d.CreateFilesystem(disk.FilesystemSpec{
 				Partition:   r.target.number,
 				FSType:      filesystem.TypeExt4,

--- a/resize_test.go
+++ b/resize_test.go
@@ -932,3 +932,131 @@ func TestShrinkFilesystems(t *testing.T) {
 		}
 	})
 }
+
+// TestUpdatePartitions verifies the idempotent finalize step: relocated copies
+// take on their originals' identities (and, with preserveNumbers, their
+// numbers), the originals are removed, and re-running is a no-op. The input
+// models the state right after copyFilesystems: the originals (2, 3) still
+// carry the real identities at their old locations, and the relocated copies
+// (5, 6) carry the alternate "<label>_resized2" identities at new locations.
+func TestUpdatePartitions(t *testing.T) {
+	const sector = 512
+	// layout in sectors (Start is an LBA; Size is in bytes for gpt.Partition)
+	const (
+		part1Start = 2048
+		imgaOrig   = part1Start + 36*MB/sector // after part1 (36MB)
+		dataOrig   = imgaOrig + 100*MB/sector  // after IMGA original (100MB)
+		part4Start = dataOrig + 50*MB/sector   // after DATA original (50MB)
+		imgaCopy   = part4Start + 36*MB/sector // after part4 (36MB)
+		dataCopy   = imgaCopy + 300*MB/sector  // after IMGA copy (300MB)
+	)
+
+	for _, preserveNumbers := range []bool{false, true} {
+		name := "renumber"
+		if preserveNumbers {
+			name = "preserveNumbers"
+		}
+		t.Run(name, func(t *testing.T) {
+			workDir := t.TempDir()
+			f, err := os.CreateTemp(workDir, "disk.img")
+			if err != nil {
+				t.Fatalf("create temp disk: %v", err)
+			}
+			defer func() { _ = f.Close() }()
+			if err := os.Truncate(f.Name(), 1*GB); err != nil {
+				t.Fatalf("truncate disk: %v", err)
+			}
+			d, err := diskfs.OpenBackend(file.New(f, false), diskfs.WithOpenMode(diskfs.ReadWrite))
+			if err != nil {
+				t.Fatalf("open disk: %v", err)
+			}
+			table := &gpt.Table{
+				Partitions: []*gpt.Partition{
+					{Index: 1, Start: part1Start, Size: 36 * MB, Type: gpt.LinuxFilesystem, Name: "part1"},
+					{Index: 2, Start: imgaOrig, Size: 100 * MB, Type: gpt.LinuxFilesystem, Name: "IMGA"},
+					{Index: 3, Start: dataOrig, Size: 50 * MB, Type: gpt.LinuxFilesystem, Name: "DATA"},
+					{Index: 4, Start: part4Start, Size: 36 * MB, Type: gpt.LinuxFilesystem, Name: "part4"},
+					{Index: 5, Start: imgaCopy, Size: 300 * MB, Type: gpt.LinuxFilesystem, Name: getAlternateLabel("IMGA")},
+					{Index: 6, Start: dataCopy, Size: 200 * MB, Type: gpt.LinuxFilesystem, Name: getAlternateLabel("DATA")},
+				},
+			}
+			if err := d.Partition(table); err != nil {
+				t.Fatalf("write partition table: %v", err)
+			}
+
+			resizes := []partitionResizeTarget{
+				{
+					original: partitionData{number: 2, label: "IMGA", start: imgaOrig * sector},
+					target:   partitionData{number: 5, start: imgaCopy * sector},
+				},
+				{
+					original: partitionData{number: 3, label: "DATA", start: dataOrig * sector},
+					target:   partitionData{number: 6, start: dataCopy * sector},
+				},
+			}
+
+			// (idempotency across a re-run is covered end-to-end by
+			// TestRunResumeAfterInterruption/*/afterUpdatePartitions, which uses
+			// a fresh disk handle as a real resume does.)
+			if err := updatePartitions(d, resizes, preserveNumbers); err != nil {
+				t.Fatalf("updatePartitions failed: %v", err)
+			}
+
+			tableRaw, err := d.GetPartitionTable()
+			if err != nil {
+				t.Fatalf("get partition table: %v", err)
+			}
+			byIndex := make(map[int]*gpt.Partition)
+			for _, p := range tableRaw.(*gpt.Table).Partitions {
+				if p.Type == gpt.Unused {
+					continue
+				}
+				byIndex[p.Index] = p
+			}
+
+			// expected final number->(label, start-sector)
+			want := map[int]struct {
+				label string
+				start uint64
+			}{
+				1: {"part1", part1Start},
+				4: {"part4", part4Start},
+			}
+			if preserveNumbers {
+				want[2] = struct {
+					label string
+					start uint64
+				}{"IMGA", imgaCopy}
+				want[3] = struct {
+					label string
+					start uint64
+				}{"DATA", dataCopy}
+			} else {
+				want[5] = struct {
+					label string
+					start uint64
+				}{"IMGA", imgaCopy}
+				want[6] = struct {
+					label string
+					start uint64
+				}{"DATA", dataCopy}
+			}
+
+			if len(byIndex) != len(want) {
+				t.Fatalf("expected %d partitions, got %d", len(want), len(byIndex))
+			}
+			for number, w := range want {
+				p, ok := byIndex[number]
+				if !ok {
+					t.Fatalf("expected partition number %d (%s) to exist", number, w.label)
+				}
+				if p.Name != w.label {
+					t.Errorf("partition %d: label = %q, want %q", number, p.Name, w.label)
+				}
+				if p.Start != w.start {
+					t.Errorf("partition %d (%s): start = %d, want %d (data must not move)", number, w.label, p.Start, w.start)
+				}
+			}
+		})
+	}
+}

--- a/resume_test.go
+++ b/resume_test.go
@@ -20,8 +20,7 @@ const (
 	stepShrinkPartitions
 	stepCreatePartitions
 	stepCopyFilesystems
-	stepSwapPartitions
-	stepFinalize // renumber (preserveNumbers) or remove
+	stepUpdatePartitions // idempotent finalize: relabel/reindex + delete original
 )
 
 // runResizeStepsUpTo replays resize()'s pipeline against a freshly planned
@@ -70,13 +69,7 @@ func runResizeStepsUpTo(t *testing.T, path string, shrink PartitionIdentifier, g
 		{"shrinkPartitions", func() error { return shrinkPartitions(d, resizes) }},
 		{"createPartitions", func() error { return createPartitions(d, resizes) }},
 		{"copyFilesystems", func() error { return copyFilesystems(d, resizes) }},
-		{"swapPartitions", func() error { return swapPartitions(d, resizes) }},
-		{"finalize", func() error {
-			if preserveNumbers {
-				return removeAndRenumberPartitions(d, resizes)
-			}
-			return removePartitions(d, resizes)
-		}},
+		{"updatePartitions", func() error { return updatePartitions(d, resizes, preserveNumbers) }},
 	}
 	for i := 0; i < stopAfter && i < len(steps); i++ {
 		if err := steps[i].fn(); err != nil {
@@ -156,11 +149,6 @@ func TestRunResumeAfterInterruption(t *testing.T) {
 		// writeExtraFile additionally leaves a stale file in the created target
 		// fs, so it is non-empty and does not match the source.
 		writeExtraFile bool
-		// knownBroken, when non-empty, marks an interruption point whose resume
-		// behavior is currently incorrect (or undecided); the case is skipped
-		// with this reason. Empty means resume is expected to work and is
-		// asserted.
-		knownBroken string
 	}{
 		{name: "afterShrinkFilesystems", stopAfter: stepShrinkFilesystems},
 		{name: "afterShrinkPartitions", stopAfter: stepShrinkPartitions},
@@ -189,17 +177,12 @@ func TestRunResumeAfterInterruption(t *testing.T) {
 			name:      "afterCopyFilesystems",
 			stopAfter: stepCopyFilesystems,
 		},
-		// swapPartitions is intended to be a single, final relabel/reindex +
-		// delete-old operation; its resume semantics are a known design TBD.
 		{
-			name:        "afterSwapPartitions",
-			stopAfter:   stepSwapPartitions,
-			knownBroken: "design TBD: swap is meant to be a single final reindex/relabel+delete; swap is not idempotent and re-running resolves the label to the already-swapped partition",
-		},
-		{
-			name:        "afterFinalize",
-			stopAfter:   stepFinalize,
-			knownBroken: "depends on the post-swap resume design (TBD)",
+			// the whole resize completed, then the tool was re-run: the
+			// idempotent updatePartitions plus the "already at target size"
+			// short-circuit in planResizes must make this a no-op.
+			name:      "afterUpdatePartitions",
+			stopAfter: stepUpdatePartitions,
 		},
 	}
 
@@ -210,9 +193,6 @@ func TestRunResumeAfterInterruption(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(mode+"/"+tc.name, func(t *testing.T) {
-				if tc.knownBroken != "" {
-					t.Skipf("resume not yet correct at this point: %s", tc.knownBroken)
-				}
 				tmpDir := t.TempDir()
 				tmpFile := filepath.Join(tmpDir, "diskfull.img")
 				if err := testCopyFile(diskfullImg, tmpFile); err != nil {

--- a/resume_test.go
+++ b/resume_test.go
@@ -1,0 +1,428 @@
+package partitionresizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/disk"
+	"github.com/diskfs/go-diskfs/filesystem"
+	"github.com/diskfs/go-diskfs/partition/gpt"
+)
+
+// resize() pipeline step boundaries, in execution order. A value of N means
+// "stop after the Nth step has written to disk", simulating a crash at that
+// point.
+const (
+	stepShrinkFilesystems = iota + 1
+	stepShrinkPartitions
+	stepCreatePartitions
+	stepCopyFilesystems
+	stepSwapPartitions
+	stepFinalize // renumber (preserveNumbers) or remove
+)
+
+// runResizeStepsUpTo replays resize()'s pipeline against a freshly planned
+// resizes slice, stopping after the step given by stopAfter. It simulates the
+// process being interrupted immediately after that step has persisted its
+// changes, so that a subsequent Run() must resume from a partially-modified
+// disk. The plan is computed exactly as Run() does, from the current on-disk
+// state.
+func runResizeStepsUpTo(t *testing.T, path string, shrink PartitionIdentifier, grow []PartitionChange, preserveNumbers bool, stopAfter int, formatTargetsNoCopy, writeExtraFile bool) {
+	t.Helper()
+	backend, err := file.OpenFromPath(path, false)
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	// close (flush) the partial handle before Run() reopens the path
+	defer func() { _ = backend.Close() }()
+
+	d, err := diskfs.OpenBackend(backend)
+	if err != nil {
+		t.Fatalf("open disk: %v", err)
+	}
+	tableRaw, err := d.GetPartitionTable()
+	if err != nil {
+		t.Fatalf("get partition table: %v", err)
+	}
+	table, ok := tableRaw.(*gpt.Table)
+	if !ok {
+		t.Fatalf("expected GPT table")
+	}
+	// for an image file, findDisks keys partition data by the file's basename
+	disks, err := findDisks(path, "")
+	if err != nil {
+		t.Fatalf("findDisks: %v", err)
+	}
+	parts := disks[filepath.Base(path)]
+	resizes, err := planResizes(d, table, parts, grow, &shrink)
+	if err != nil {
+		t.Fatalf("planResizes: %v", err)
+	}
+
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"shrinkFilesystems", func() error { return shrinkFilesystems(d, resizes, false) }},
+		{"shrinkPartitions", func() error { return shrinkPartitions(d, resizes) }},
+		{"createPartitions", func() error { return createPartitions(d, resizes) }},
+		{"copyFilesystems", func() error { return copyFilesystems(d, resizes) }},
+		{"swapPartitions", func() error { return swapPartitions(d, resizes) }},
+		{"finalize", func() error {
+			if preserveNumbers {
+				return removeAndRenumberPartitions(d, resizes)
+			}
+			return removePartitions(d, resizes)
+		}},
+	}
+	for i := 0; i < stopAfter && i < len(steps); i++ {
+		if err := steps[i].fn(); err != nil {
+			t.Fatalf("partial step %q failed: %v", steps[i].name, err)
+		}
+	}
+
+	// formatTargetsNoCopy simulates a crash *inside* copyFilesystems: the
+	// target filesystem has been created (CreateFilesystem) but no data has
+	// been copied into it yet. This is the case that forces the resume path to
+	// run CreateFilesystem over an already-formatted partition.
+	if formatTargetsNoCopy {
+		for _, r := range resizes {
+			if r.original.start == r.target.start {
+				continue
+			}
+			src, err := d.GetFilesystem(r.original.number)
+			if err != nil {
+				continue // raw-copy types (squashfs/unknown): nothing to pre-create
+			}
+			switch src.Type() {
+			case filesystem.TypeExt4, filesystem.TypeFat32:
+				newFS, err := d.CreateFilesystem(disk.FilesystemSpec{
+					Partition:   r.target.number,
+					FSType:      src.Type(),
+					VolumeLabel: src.Label(),
+				})
+				if err != nil {
+					t.Fatalf("pre-create target fs on partition %d: %v", r.target.number, err)
+				}
+				if writeExtraFile {
+					// Leave a stale file behind so the target is non-empty and
+					// does NOT match the source: CompareFS must report the
+					// difference and the resume must reformat+recopy (the stale
+					// file must be gone in the final result).
+					fh, err := newFS.OpenFile("/resume-junk.bin", os.O_CREATE|os.O_RDWR)
+					if err != nil {
+						t.Fatalf("open junk file on target %d: %v", r.target.number, err)
+					}
+					if _, err := fh.Write([]byte("stale data from an interrupted run; must be discarded")); err != nil {
+						t.Fatalf("write junk file on target %d: %v", r.target.number, err)
+					}
+					if err := fh.Close(); err != nil {
+						t.Fatalf("close junk file on target %d: %v", r.target.number, err)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestRunResumeAfterInterruption verifies restart-safety: the tool is
+// interrupted after each step of the resize pipeline, then re-run, and the
+// final disk must match the result of an uninterrupted run.
+//
+// This exercises the user-driven "the machine rebooted mid-resize, run it
+// again" operation, which has no coverage today (the only resume guard,
+// createPartitions' "alternate partition already exists" branch, is never hit
+// by a test). It is the functional counterpart to those uncovered blocks.
+func TestRunResumeAfterInterruption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow end-to-end resize test (real shrink/copy of a multi-GB fixture)")
+	}
+	shrink := NewPartitionIdentifier(IdentifierByLabel, "shrinker")
+	grow := []PartitionChange{
+		NewPartitionChange(IdentifierByLabel, "parta", 2*GB),
+		NewPartitionChange(IdentifierByLabel, "partb", 2*GB),
+		NewPartitionChange(IdentifierByLabel, "ESP", 1*GB),
+	}
+
+	cases := []struct {
+		name      string
+		stopAfter int
+		// formatTargetsNoCopy simulates a crash inside copyFilesystems (target
+		// filesystem created, data not yet copied).
+		formatTargetsNoCopy bool
+		// writeExtraFile additionally leaves a stale file in the created target
+		// fs, so it is non-empty and does not match the source.
+		writeExtraFile bool
+		// knownBroken, when non-empty, marks an interruption point whose resume
+		// behavior is currently incorrect (or undecided); the case is skipped
+		// with this reason. Empty means resume is expected to work and is
+		// asserted.
+		knownBroken string
+	}{
+		{name: "afterShrinkFilesystems", stopAfter: stepShrinkFilesystems},
+		{name: "afterShrinkPartitions", stopAfter: stepShrinkPartitions},
+		{
+			name:      "afterCreatePartitions",
+			stopAfter: stepCreatePartitions,
+		},
+		{
+			// crash mid-copy: target fs created but empty, so resume must
+			// CreateFilesystem over an already-formatted partition, then copy.
+			name:                "midCopyTargetFsCreated",
+			stopAfter:           stepCreatePartitions,
+			formatTargetsNoCopy: true,
+		},
+		{
+			// crash mid-copy with a non-empty, mismatched target (a stale file
+			// from a prior run): CompareFS reports the difference, so resume
+			// reformats over the populated fs and recopies; the stale file is
+			// gone in the final result.
+			name:                "midCopyTargetFsHasStaleFile",
+			stopAfter:           stepCreatePartitions,
+			formatTargetsNoCopy: true,
+			writeExtraFile:      true,
+		},
+		{
+			name:      "afterCopyFilesystems",
+			stopAfter: stepCopyFilesystems,
+		},
+		// swapPartitions is intended to be a single, final relabel/reindex +
+		// delete-old operation; its resume semantics are a known design TBD.
+		{
+			name:        "afterSwapPartitions",
+			stopAfter:   stepSwapPartitions,
+			knownBroken: "design TBD: swap is meant to be a single final reindex/relabel+delete; swap is not idempotent and re-running resolves the label to the already-swapped partition",
+		},
+		{
+			name:        "afterFinalize",
+			stopAfter:   stepFinalize,
+			knownBroken: "depends on the post-swap resume design (TBD)",
+		},
+	}
+
+	for _, preserveNumbers := range []bool{false, true} {
+		mode := "renumber"
+		if preserveNumbers {
+			mode = "preserveNumbers"
+		}
+		for _, tc := range cases {
+			t.Run(mode+"/"+tc.name, func(t *testing.T) {
+				if tc.knownBroken != "" {
+					t.Skipf("resume not yet correct at this point: %s", tc.knownBroken)
+				}
+				tmpDir := t.TempDir()
+				tmpFile := filepath.Join(tmpDir, "diskfull.img")
+				if err := testCopyFile(diskfullImg, tmpFile); err != nil {
+					t.Fatalf("failed to copy disk image: %v", err)
+				}
+				origShrinkSize, origNumber := readOriginalLayout(t, tmpFile)
+
+				// simulate a crash partway through the resize
+				runResizeStepsUpTo(t, tmpFile, shrink, grow, preserveNumbers, tc.stopAfter, tc.formatTargetsNoCopy, tc.writeExtraFile)
+
+				// resume: a fresh Run() must finish the resize correctly
+				if err := Run(tmpFile, &shrink, grow, false, false, preserveNumbers); err != nil {
+					t.Fatalf("resume Run failed: %v", err)
+				}
+
+				assertResizedLayout(t, tmpFile, origShrinkSize, origNumber, preserveNumbers)
+			})
+		}
+	}
+}
+
+// readOriginalLayout records the shrinker partition size and the original
+// partition numbers from a pristine disk image, for later comparison.
+func readOriginalLayout(t *testing.T, path string) (shrinkSize int64, numbers map[string]int) {
+	t.Helper()
+	backend, err := file.OpenFromPath(path, true)
+	if err != nil {
+		t.Fatalf("open original backend: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+	d, err := diskfs.OpenBackend(backend)
+	if err != nil {
+		t.Fatalf("open original disk: %v", err)
+	}
+	tableRaw, err := d.GetPartitionTable()
+	if err != nil {
+		t.Fatalf("get original partition table: %v", err)
+	}
+	table := tableRaw.(*gpt.Table)
+	numbers = map[string]int{}
+	for _, p := range table.Partitions {
+		if p.Type == gpt.Unused {
+			continue
+		}
+		numbers[p.Name] = int(p.Index)
+		if p.Name == "shrinker" {
+			shrinkSize = int64(p.GetSize())
+		}
+	}
+	if shrinkSize == 0 {
+		t.Fatal("could not find shrinker partition in original disk")
+	}
+	return shrinkSize, numbers
+}
+
+// assertResizedLayout checks that the disk reflects a completed resize:
+// shrinker shrunk by the total grow, the three grown partitions at their
+// requested sizes, ESP still FAT32, and (when preserveNumbers) every partition
+// keeping its original number. This is the same end state asserted by
+// TestRun's uninterrupted path.
+func assertResizedLayout(t *testing.T, path string, origShrinkSize int64, origNumber map[string]int, preserveNumbers bool) {
+	t.Helper()
+	backend, err := file.OpenFromPath(path, true)
+	if err != nil {
+		t.Fatalf("open resized backend: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+	d, err := diskfs.OpenBackend(backend)
+	if err != nil {
+		t.Fatalf("open resized disk: %v", err)
+	}
+	tableRaw, err := d.GetPartitionTable()
+	if err != nil {
+		t.Fatalf("get resized partition table: %v", err)
+	}
+	table := tableRaw.(*gpt.Table)
+
+	var active []*gpt.Partition
+	for _, p := range table.Partitions {
+		if p.Type != gpt.Unused {
+			active = append(active, p)
+		}
+	}
+	if len(active) != 4 {
+		t.Fatalf("expected 4 active partitions, got %d: %+v", len(active), active)
+	}
+
+	totalGrow := int64(2*GB + 2*GB + 1*GB)
+	expectShrink := origShrinkSize - totalGrow
+
+	seen := map[string]bool{}
+	for _, p := range active {
+		name := p.Name
+		size := int64(p.GetSize())
+		switch name {
+		case "shrinker":
+			if size != expectShrink {
+				t.Errorf("shrinker size = %d, want %d", size, expectShrink)
+			}
+		case "parta", "partb":
+			if size != int64(2*GB) {
+				t.Errorf("%s size = %d, want %d", name, size, 2*GB)
+			}
+		case "ESP":
+			if size != int64(1*GB) {
+				t.Errorf("ESP size = %d, want %d", size, 1*GB)
+			}
+			fs, err := d.GetFilesystem(int(p.Index))
+			if err != nil {
+				t.Errorf("get ESP filesystem: %v", err)
+			} else if fs.Type() != filesystem.TypeFat32 {
+				t.Errorf("ESP filesystem type = %v, want FAT32", fs.Type())
+			}
+		default:
+			t.Errorf("unexpected active partition %q", name)
+		}
+		if preserveNumbers && int(p.Index) != origNumber[name] {
+			t.Errorf("%s number = %d, want %d (preserveNumbers)", name, p.Index, origNumber[name])
+		}
+		seen[name] = true
+	}
+	for _, n := range []string{"shrinker", "parta", "partb", "ESP"} {
+		if !seen[n] {
+			t.Errorf("missing active partition %q", n)
+		}
+	}
+}
+
+// TestRunAbortsOnFsckFailure verifies that when the shrink partition's ext4
+// filesystem is corrupt, the e2fsck run inside the shrink step fails and the
+// whole resize aborts (with fixErrors=false) rather than shrinking a broken
+// filesystem. This is the user-driven "the source filesystem is damaged"
+// case: the tool must refuse, not proceed.
+func TestRunAbortsOnFsckFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow end-to-end resize test (real shrink/copy of a multi-GB fixture)")
+	}
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "diskfull.img")
+	if err := testCopyFile(diskfullImg, tmpFile); err != nil {
+		t.Fatalf("failed to copy disk image: %v", err)
+	}
+
+	shrinkStart := partitionStartByLabel(t, tmpFile, "shrinker")
+
+	// Corrupt ext4 metadata well past the primary superblock (+1024) and group
+	// descriptors, so GetFilesystem still recognizes the filesystem as ext4 but
+	// e2fsck -f finds errors. 4 MiB of garbage at +2 MiB lands in the early
+	// inode tables/bitmaps.
+	corruptRegion(t, tmpFile, shrinkStart+2*1024*1024, 4*1024*1024)
+
+	shrink := NewPartitionIdentifier(IdentifierByLabel, "shrinker")
+	grow := []PartitionChange{
+		NewPartitionChange(IdentifierByLabel, "parta", 2*GB),
+		NewPartitionChange(IdentifierByLabel, "partb", 2*GB),
+		NewPartitionChange(IdentifierByLabel, "ESP", 1*GB),
+	}
+
+	// fixErrors=false: e2fsck -n must refuse the corrupt fs and the resize must
+	// abort before touching the partition layout.
+	err := Run(tmpFile, &shrink, grow, false, false, false)
+	if err == nil {
+		t.Fatal("expected Run to fail on a corrupt shrink filesystem, got nil")
+	}
+	t.Logf("Run correctly aborted on corrupt shrink filesystem: %v", err)
+}
+
+// partitionStartByLabel returns the byte offset of the named GPT partition.
+func partitionStartByLabel(t *testing.T, path, label string) int64 {
+	t.Helper()
+	backend, err := file.OpenFromPath(path, true)
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+	d, err := diskfs.OpenBackend(backend)
+	if err != nil {
+		t.Fatalf("open disk: %v", err)
+	}
+	tableRaw, err := d.GetPartitionTable()
+	if err != nil {
+		t.Fatalf("get partition table: %v", err)
+	}
+	table := tableRaw.(*gpt.Table)
+	for _, p := range table.Partitions {
+		if p.Name == label {
+			return p.GetStart()
+		}
+	}
+	t.Fatalf("partition %q not found", label)
+	return 0
+}
+
+// corruptRegion overwrites length bytes at offset in the file with a fixed
+// non-zero pattern.
+func corruptRegion(t *testing.T, path string, offset, length int64) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open for corruption: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	junk := make([]byte, length)
+	for i := range junk {
+		junk[i] = 0xAB
+	}
+	if _, err := f.WriteAt(junk, offset); err != nil {
+		t.Fatalf("write corruption: %v", err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("sync corruption: %v", err)
+	}
+}

--- a/run_helpers.go
+++ b/run_helpers.go
@@ -139,6 +139,13 @@ func planResizes(
 	}
 	var done, pending []partitionResizeTarget
 	for _, pr := range prTargets {
+		// Already at the requested size: nothing to do. This is a grow that a
+		// prior, interrupted run already finished (the label now resolves to the
+		// finalized, grown partition), or simply a no-op request. A genuine
+		// shrink (original larger than target) is left to calculateResizes.
+		if pr.original.size == pr.target.size {
+			continue
+		}
 		alt, ok := existingByName[getAlternateLabel(pr.original.label)]
 		if !ok {
 			pending = append(pending, pr)

--- a/run_helpers.go
+++ b/run_helpers.go
@@ -121,10 +121,50 @@ func planResizes(
 		return nil, err
 	}
 
-	// try to calculate without shrinking
-	resizes, err := calculateResizes(d.Size, table.Partitions, prTargets)
+	// Resume support: an interrupted run may already have created the relocated
+	// "<label>_resized2" partition for some grows. Those targets already occupy
+	// their final space, so they must be excluded from (re)planning. If we
+	// instead fed them back through calculateResizes, their space would count as
+	// occupied, the grow would no longer fit, and a second shrink of the shrink
+	// partition would be planned -- driving its size negative
+	// (diskfs/partitionresizer#13). Split the grows already created from those
+	// still pending, and reuse the existing partition's geometry as the target
+	// for the created ones.
+	existingByName := make(map[string]*gpt.Partition)
+	for _, p := range table.Partitions {
+		if p.Type == gpt.Unused {
+			continue
+		}
+		existingByName[p.Name] = p
+	}
+	var done, pending []partitionResizeTarget
+	for _, pr := range prTargets {
+		alt, ok := existingByName[getAlternateLabel(pr.original.label)]
+		if !ok {
+			pending = append(pending, pr)
+			continue
+		}
+		start := alt.GetStart()
+		size := int64(alt.GetSize())
+		pr.target = partitionData{
+			label:  alt.Name,
+			size:   size,
+			start:  start,
+			end:    start + size - 1,
+			number: alt.Index,
+		}
+		done = append(done, pr)
+	}
+
+	// every grow is already created: nothing left to allocate or shrink
+	if len(pending) == 0 {
+		return done, nil
+	}
+
+	// try to calculate without shrinking, for the pending grows only
+	resizes, err := calculateResizes(d.Size, table.Partitions, pending)
 	if err == nil {
-		return resizes, nil
+		return append(done, resizes...), nil
 	}
 	var spaceErr *InsufficientSpaceError
 	if !errors.As(err, &spaceErr) {
@@ -136,9 +176,9 @@ func planResizes(
 		return nil, fmt.Errorf("insufficient space to perform requested partition grows, and no shrink partition specified")
 	}
 
-	// compute total space to grow (rounded up to next GB)
+	// compute total space to grow (rounded up to next GB) for the pending grows
 	var totalGrow int64
-	for _, gp := range prTargets {
+	for _, gp := range pending {
 		totalGrow += gp.target.size
 	}
 	if totalGrow%GB != 0 {
@@ -164,10 +204,14 @@ func planResizes(
 		target:   target,
 	}
 	prTargetsWithShrink := []partitionResizeTarget{shrink}
-	prTargetsWithShrink = append(prTargetsWithShrink, prTargets...)
+	prTargetsWithShrink = append(prTargetsWithShrink, pending...)
 
 	// recalculate resizes with shrinking
-	return calculateResizes(d.Size, table.Partitions, prTargetsWithShrink)
+	resizes, err = calculateResizes(d.Size, table.Partitions, prTargetsWithShrink)
+	if err != nil {
+		return nil, err
+	}
+	return append(done, resizes...), nil
 }
 
 // partitionDevicePath maps a whole-disk path (e.g. "/dev/sda") and a


### PR DESCRIPTION
Fixes #13.

## Problem

A resize interrupted (e.g. the machine reboots mid-operation) and then re-run
could corrupt the disk. `planResizes` recomputes the plan from the *current*
on-disk state each run; once the relocated `*_resized2` partitions have been
created, that space is occupied, the grows no longer fit, and a **second**
shrink of the shrink partition is planned — driving its target size negative.

## Fix

- **Resume-aware `planResizes`**: a grow whose relocated `*_resized2` partition
  already exists is reused in place and excluded from the space/shrink
  re-planning, so no second shrink is computed.
- **`copyFilesystems` copy-skip**: when the target already holds a filesystem
  matching the source (`sync.CompareFS`), the reformat+recopy is skipped;
  otherwise it reformats (over an empty or non-matching target) and recopies.
- **Idempotent `updatePartitions` finalize**: replaces the non-idempotent
  `swapPartitions` + `removePartitions`/`removeAndRenumberPartitions` finalize
  with a single partition-table write that relabels/reindexes each relocated
  target and removes the original, keyed on the stable on-disk start offset, so
  a re-run converges instead of undoing a completed operation. This makes the
  finalize step itself safe to resume.

## Tests (`resume_test.go`)

`TestRunResumeAfterInterruption` interrupts the pipeline after each step and
re-runs to completion, asserting the final disk matches an uninterrupted run:
`afterShrinkFilesystems`, `afterShrinkPartitions`, `afterCreatePartitions`,
`midCopyTargetFsCreated`, `midCopyTargetFsHasStaleFile`, `afterCopyFilesystems`,
and `afterUpdatePartitions` (whole resize completed → re-run is a no-op) — in
both `renumber` and `preserveNumbers` modes. `TestUpdatePartitions` covers the
finalize transformation directly. `TestRunAbortsOnFsckFailure` asserts the
resize aborts on e2fsck failure rather than shrinking a broken filesystem.

`swapPartitions`/`removePartitions`/`removeAndRenumberPartitions` remain defined
but are no longer called by `resize`.

These cases run a real shrink/copy of a multi-GB fixture, so they are guarded by
`testing.Short()` and the CI test timeout is raised to 30m.
