### PR TITLE
resize: fix shrinkPartitions for non-contiguous partition numbers

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -298,17 +298,28 @@ func shrinkPartitions(d *disk.Disk, resizes []partitionResizeTarget) error {
 	if !ok {
 		return fmt.Errorf("unsupported partition table type, only GPT is supported")
 	}
+	// Look up partitions by their GPT Index, not by slice position.
+	// table.Partitions is compacted (only active entries), so the old
+	// table.Partitions[number-1] assumed a contiguous 1..N numbering and
+	// indexed the wrong entry -- or panicked -- on any non-contiguous layout
+	// (e.g. EVE's persist partition at index 9).
+	byIndex := make(map[int]*gpt.Partition)
+	for _, p := range table.Partitions {
+		byIndex[p.Index] = p
+	}
 	for _, r := range resizes {
 		if r.original.size <= r.target.size {
 			log.Printf("partition %d does not require shrinking, skipping", r.original.number)
 			continue
 		}
+		p, ok := byIndex[r.original.number]
+		if !ok {
+			return fmt.Errorf("partition %d not found in partition table", r.original.number)
+		}
 		log.Printf("Resizing partition %d to %d bytes", r.original.number, r.target.size)
-		// Update GPT entry for the shrink partition (indexed by number-1)
-		// set the new desired size
-		table.Partitions[r.original.number-1].Size = uint64(r.target.size)
-		// set the end to 0, so that it will be recalculated
-		table.Partitions[r.original.number-1].End = 0
+		// set the new desired size; set End to 0 so it is recalculated
+		p.Size = uint64(r.target.size)
+		p.End = 0
 		resizeCount++
 	}
 	if resizeCount == 0 {

--- a/shrinkpartitions_test.go
+++ b/shrinkpartitions_test.go
@@ -1,0 +1,77 @@
+package partitionresizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/partition/gpt"
+)
+
+// TestShrinkPartitionsSparseIndex verifies shrinkPartitions on a non-contiguous
+// GPT layout, where a partition's number is not its slice position + 1 (e.g.
+// EVE's persist partition at index 9 with gaps below it). d.Table.Partitions is
+// a compacted slice of only the active partitions, so the previous
+// table.Partitions[number-1] indexing either touched the wrong entry or
+// panicked with index-out-of-range. The fix looks the partition up by Index.
+func TestShrinkPartitionsSparseIndex(t *testing.T) {
+	const sector = 512
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "disk.img")
+	f, err := os.Create(imgPath)
+	if err != nil {
+		t.Fatalf("create disk image: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Truncate(256 * MB); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	d, err := diskfs.OpenBackend(file.New(f, false), diskfs.WithOpenMode(diskfs.ReadWrite))
+	if err != nil {
+		t.Fatalf("open disk: %v", err)
+	}
+
+	p1Start := uint64(2048)
+	p9Start := p1Start + 36*MB/sector
+	table := &gpt.Table{
+		Partitions: []*gpt.Partition{
+			{Index: 1, Start: p1Start, Size: 36 * MB, Type: gpt.LinuxFilesystem, Name: "p1"},
+			// index 9, slice position 1: the case that broke table.Partitions[8]
+			{Index: 9, Start: p9Start, Size: 128 * MB, Type: gpt.LinuxFilesystem, Name: "P9"},
+		},
+	}
+	if err := d.Partition(table); err != nil {
+		t.Fatalf("write partition table: %v", err)
+	}
+
+	// shrink P9 (index 9) from 128 MB to 64 MB
+	resizes := []partitionResizeTarget{{
+		original: partitionData{number: 9, label: "P9", size: 128 * MB},
+		target:   partitionData{number: 9, size: 64 * MB},
+	}}
+	if err := shrinkPartitions(d, resizes); err != nil {
+		t.Fatalf("shrinkPartitions failed: %v", err)
+	}
+
+	tr, err := d.GetPartitionTable()
+	if err != nil {
+		t.Fatalf("get partition table: %v", err)
+	}
+	byIndex := make(map[int]*gpt.Partition)
+	for _, p := range tr.(*gpt.Table).Partitions {
+		if p.Type == gpt.Unused {
+			continue
+		}
+		byIndex[p.Index] = p
+	}
+	if got := int64(byIndex[9].GetSize()); got != 64*MB {
+		t.Errorf("P9 (index 9) size = %d, want %d", got, 64*MB)
+	}
+	// the partition at slice position 8 does not exist; the partition that the
+	// old code would have touched (index 1) must be left alone
+	if got := int64(byIndex[1].GetSize()); got != 36*MB {
+		t.Errorf("p1 (index 1) size = %d, want %d (must be untouched)", got, 36*MB)
+	}
+}


### PR DESCRIPTION
## Problem

`shrinkPartitions` located the partition to shrink with
`table.Partitions[r.original.number-1]`, assuming partition number *N* sits at
slice position *N-1* (a contiguous 1..N numbering). But `d.Table.Partitions` is
a **compacted** slice containing only the active partitions, so on a
non-contiguous layout this indexes the wrong entry — or panics with
index-out-of-range.

This is not hypothetical: EVE's disk has gaps in its partition numbering and
puts the persist filesystem at **index 9**. Shrinking it (a two-entry table →
`table.Partitions[8]`) panics, so partitionresizer would crash shrinking
persist on a real EVE device.

## Fix

Look the partition up by its GPT `Index`, the way the other table-mutating
helpers (`createPartitions`, `swapPartitions`, …) already do.

## Test

`TestShrinkPartitionsSparseIndex` builds a two-entry table with a partition at
index 9 and shrinks it, asserting the right partition changes size and the
other is untouched. It panics on the old code and passes on the fix.

This is an independent crash fix with no dependency on the other in-flight
partitionresizer work.
