### PR TITLE
cmd/resizer: fix panic on grow-only invocation (no --shrink-partition)

### DIFF
--- a/cmd/resizer/grow_only_test.go
+++ b/cmd/resizer/grow_only_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/partition/gpt"
+)
+
+// TestGrowOnlyDoesNotPanic builds the resizer and runs a grow-only invocation
+// (no --shrink-partition) against a minimal GPT image. Before the fix, main
+// passed Run a non-nil pointer to a nil PartitionIdentifier, which made
+// filterDisksByPartitions nil-dereference and the process panic (exit 2). After
+// the fix it must fail gracefully (here: insufficient space), never panic.
+func TestGrowOnlyDoesNotPanic(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "resizer")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build resizer: %v\n%s", err, out)
+	}
+	img := makeMinimalGPTImage(t)
+
+	cmd := exec.Command(bin, "--grow-partition", "label:data:1G", img)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if strings.Contains(stderr.String(), "panic:") {
+		t.Fatalf("grow-only invocation panicked:\n%s", stderr.String())
+	}
+	if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 2 {
+		t.Fatalf("grow-only invocation crashed (exit 2 = panic):\n%s", stderr.String())
+	}
+	// a clean non-zero exit (e.g. insufficient space) is the expected behavior
+	t.Logf("grow-only exited cleanly: err=%v\n%s", err, strings.TrimSpace(stderr.String()))
+}
+
+// makeMinimalGPTImage writes a small disk image with a valid GPT containing one
+// "data" partition, enough for discovery to succeed and reach the matching path.
+func makeMinimalGPTImage(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "disk.img")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+	if err := f.Truncate(64 * 1024 * 1024); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	_ = f.Close()
+
+	f, err = os.OpenFile(p, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	d, err := diskfs.OpenBackend(file.New(f, false), diskfs.WithOpenMode(diskfs.ReadWrite))
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	table := &gpt.Table{
+		Partitions: []*gpt.Partition{
+			{Index: 1, Start: 2048, Size: 16 * 1024 * 1024, Type: gpt.LinuxFilesystem, Name: "data"},
+		},
+	}
+	if err := d.Partition(table); err != nil {
+		t.Fatalf("write partition table: %v", err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	return p
+}

--- a/cmd/resizer/main.go
+++ b/cmd/resizer/main.go
@@ -47,16 +47,19 @@ var rootCmd = func() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			// check validity of flags
 			var (
-				shrinkPartitionParsed resizer.PartitionIdentifier
-				growPartitionsParsed  []resizer.PartitionChange
-				disk                  string
+				shrinkPartitionPtr   *resizer.PartitionIdentifier
+				growPartitionsParsed []resizer.PartitionChange
+				disk                 string
 			)
 			if shrinkPartition != "" {
-				var err error
-				shrinkPartitionParsed, err = parsePartitionIdentifier(shrinkPartition)
+				parsed, err := parsePartitionIdentifier(shrinkPartition)
 				if err != nil {
 					log.Fatalf("Invalid shrink-partition value: %v", err)
 				}
+				// only pass a non-nil pointer when a shrink partition was given;
+				// passing &(nil interface) makes Run treat it as a real
+				// partition and panic in filterDisksByPartitions
+				shrinkPartitionPtr = &parsed
 			}
 			for _, gp := range growPartitions {
 				gpParsed, err := parsePartitionChange(gp)
@@ -71,7 +74,7 @@ var rootCmd = func() *cobra.Command {
 			if len(args) > 0 {
 				disk = args[0]
 			}
-			if err := resizer.Run(disk, &shrinkPartitionParsed, growPartitionsParsed, fixErrors, dryRun); err != nil {
+			if err := resizer.Run(disk, shrinkPartitionPtr, growPartitionsParsed, fixErrors, dryRun); err != nil {
 				log.Fatalf("Resize operation failed: %v", err)
 			}
 		},


### PR DESCRIPTION
## Problem

`resizer --grow-partition <id>:<size> <disk>` with **no `--shrink-partition`** —
the common "grow into existing free space" case — **panics** with a nil pointer
dereference.

`main` declared `var shrinkPartitionParsed resizer.PartitionIdentifier` (a nil
interface when the flag is omitted) and always passed `&shrinkPartitionParsed`.
`Run` treats a non-nil `*PartitionIdentifier` as "a shrink partition was given",
appends `*shrinkPartition` (the nil interface) to the partition list it
discovers against, and `filterDisksByPartitions` then calls `.By()` on the nil
identifier → crash.

## Fix

Pass `nil` when `--shrink-partition` is not given.

## Test

`TestGrowOnlyDoesNotPanic` builds the binary and runs a grow-only invocation
against a minimal GPT image, asserting it does not panic (exit 2 / `panic:`).
It panics without this fix and exits cleanly (insufficient space) with it.

Independent crash fix; no dependency on the other in-flight PRs. Off `main`.
