### PR TITLE
resize: integrity-check all source filesystems (e2fsck + fsck.fat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ It has the following handling for filesystems:
 
 ## Dependencies
 
-The only external dependency is the ext4 utils `resize2fs` and `e2fsck`, which are part of the `e2fsprogs-extras` package on Linux,
-and brew formula `e2fsprogs` on macOS.
+resizer shells out to the standard filesystem tools:
 
-If you do not need to resize an ext4 filesystem, you do not need to have this installed.
+* `resize2fs` and `e2fsck` for ext4 (shrinking and ext4 integrity checks) — the `e2fsprogs-extras` package on Linux, brew formula `e2fsprogs` on macOS.
+* `fsck.fat` for FAT32 integrity checks — the `dosfstools` package on Linux, brew formula `dosfstools` on macOS.
+
+You only need the tools for the filesystem types you actually touch: an ext4 source (shrink or grow) needs `e2fsprogs`, and a FAT32 grow source needs `dosfstools`. If a resize involves neither, no external tool is required.
 
 ## Block devices
 
@@ -51,4 +53,76 @@ Grow partition named sda2 to 50G on disk image file disk.img:
 ```sh
 resizer --grow-partition name:sda2:50G disk.img
 ```
+
+## Options
+
+```
+resizer [flags] <disk>
+```
+
+`<disk>` is the disk image file or block device to operate on.
+
+| Flag | Description |
+| --- | --- |
+| `--grow-partition identifier:partition:size` | Partition to grow and its target size, in `identifier:partition:size` form (e.g. `name:sda1:20G`, `label:Data:100M`). Repeatable; at least one is required. |
+| `--shrink-partition identifier:partition` | Optional ext4 partition to shrink to make space, used only if there is not enough free space for the grows. |
+| `--fix-errors` | Repair filesystem errors found while checking the source filesystems (ext4 via `e2fsck -y`, FAT32 via `fsck.fat -a`) instead of aborting on an inconsistent source. Default is a read-only check that aborts on any inconsistency. |
+| `--dry-run` | Plan the resize and log it, but make no changes. |
+| `--preserve-numbers` | Renumber a relocated (grown) partition back to its original partition number, so consumers that reference it by number (e.g. `/dev/sda2`) still find it. |
+
+Partitions are identified by `name` (e.g. `name:sda1`) or `label` (e.g.
+`label:EFI System`). Sizes accept `B`, `K`, `M`, `G`, or `T` suffixes.
+
+## Library use
+
+resizer is also importable as a Go package. The entry point is `Run`, which
+performs the same operation as the CLI:
+
+```go
+import (
+	"log"
+
+	resizer "github.com/diskfs/partitionresizer"
+)
+
+func main() {
+	// optional ext4 partition to shrink for space; pass nil to disable shrinking
+	shrink := resizer.NewPartitionIdentifier(resizer.IdentifierByName, "sda3")
+
+	// partitions to grow, with their target sizes (in bytes)
+	grows := []resizer.PartitionChange{
+		resizer.NewPartitionChange(resizer.IdentifierByName, "sda1", 20*resizer.GB),
+		resizer.NewPartitionChange(resizer.IdentifierByLabel, "Data", 100*resizer.GB),
+	}
+
+	// Run(disk, shrink, grows, fixErrors, dryRun, preserveNumbers)
+	//   disk            -- image file path or block device
+	//   fixErrors       -- repair filesystem errors (e2fsck -y / fsck.fat -a) instead of read-only checks
+	//   dryRun          -- plan only, make no changes
+	//   preserveNumbers -- renumber a relocated partition back to its original number
+	if err := resizer.Run("/dev/sda", &shrink, grows, false, false, true); err != nil {
+		log.Fatalf("resize failed: %v", err)
+	}
+}
+```
+
+Partitions are selected with `IdentifierByName`, `IdentifierByLabel`, or
+`IdentifierByUUID`. Sizes passed to `NewPartitionChange` are in bytes; the
+exported `KB`, `MB`, and `GB` constants are convenient multipliers.
+
+### Errors
+
+`Run` returns a non-nil `error` for any failure. The error wraps the failing
+tool's exit status and, for the filesystem tools, includes the tail of their
+stderr, so a caller gets the reason — not just `exit status N`. Tool output is
+also streamed live to the process's stdout/stderr.
+
+### Pre-flight integrity checks
+
+Before making any change, `Run` integrity-checks every source filesystem it will
+read or modify — the shrink partition and each grow source. ext4 sources are
+checked with `e2fsck` and FAT32 sources with `fsck.fat`. By default the checks
+are read-only and an inconsistent filesystem aborts the resize; pass `fixErrors`
+to repair instead. squashfs sources are copied raw and have no applicable check,
+so a corrupt squashfs source is reproduced faithfully.
 

--- a/cmd/resizer/main.go
+++ b/cmd/resizer/main.go
@@ -83,7 +83,7 @@ var rootCmd = func() *cobra.Command {
 	cmd.Flags().StringVar(&shrinkPartition, "shrink-partition", "", "Partition to shrink to make space, if necessary")
 	cmd.Flags().StringSliceVar(&growPartitions, "grow-partition", []string{}, "Partitions to grow, along with their desired sizes, in format identifier:partition:size, see help (e.g. name:sda1:20G or label:EFI System:100M)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "If set, will only simulate the resize operations without making any changes")
-	cmd.Flags().BoolVar(&fixErrors, "fix-errors", false, "If set, will attempt to fix any ext4 filesystem errors found during fsck before shrinking")
+	cmd.Flags().BoolVar(&fixErrors, "fix-errors", false, "If set, repair filesystem errors found while checking the source filesystems (ext4 via e2fsck -y, FAT32 via fsck.fat -a) instead of aborting on an inconsistent source")
 	cmd.Flags().BoolVar(&preserveNumbers, "preserve-numbers", false, "If set, a grown partition that is relocated is renumbered back to its original partition number, so labels keep their original partition numbers (e.g. /dev/sda2)")
 	return cmd
 }

--- a/preflight_test.go
+++ b/preflight_test.go
@@ -1,0 +1,256 @@
+package partitionresizer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/backend/file"
+	"github.com/diskfs/go-diskfs/disk"
+	"github.com/diskfs/go-diskfs/filesystem"
+	"github.com/diskfs/go-diskfs/filesystem/squashfs"
+	"github.com/diskfs/go-diskfs/partition/gpt"
+)
+
+// openFixtureExt4 copies the small fixture image (which has an ext4 partition)
+// to a temp file, opens it read-write via a path so the backend has a non-empty
+// Path(), and returns the disk plus the ext4 partition's data.
+func openFixtureExt4(t *testing.T) (*disk.Disk, partitionData, func()) {
+	t.Helper()
+	tmpFile := filepath.Join(t.TempDir(), "disk.img")
+	if err := testCopyFile(imgFile, tmpFile); err != nil {
+		t.Fatalf("copy fixture: %v", err)
+	}
+	backend, err := file.OpenFromPath(tmpFile, false)
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	d, err := diskfs.OpenBackend(backend, diskfs.WithOpenMode(diskfs.ReadWrite))
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("open disk: %v", err)
+	}
+	tableRaw, err := d.GetPartitionTable()
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("get partition table: %v", err)
+	}
+	table := tableRaw.(*gpt.Table)
+	for _, p := range table.Partitions {
+		fs, fsErr := d.GetFilesystem(p.Index)
+		if fsErr == nil && fs.Type() == filesystem.TypeExt4 {
+			pd := partitionData{
+				number: p.Index,
+				start:  int64(p.Start) * int64(table.LogicalSectorSize),
+				size:   int64(p.Size),
+				label:  p.Name,
+			}
+			return d, pd, func() { _ = backend.Close() }
+		}
+	}
+	_ = backend.Close()
+	t.Fatal("fixture has no ext4 partition; check buildimg.sh")
+	return nil, partitionData{}, nil
+}
+
+func TestCheckSourceFilesystems(t *testing.T) {
+	t.Run("ext4 source is checked with e2fsck", func(t *testing.T) {
+		d, ext4, cleanup := openFixtureExt4(t)
+		defer cleanup()
+
+		origE, origF := execE2fsck, execFsckFat
+		defer func() { execE2fsck, execFsckFat = origE, origF }()
+		var e2fsckCalls, fatCalls int
+		execE2fsck = func(string, bool) error { e2fsckCalls++; return nil }
+		execFsckFat = func(string, bool) error { fatCalls++; return nil }
+
+		resizes := []partitionResizeTarget{{original: ext4, target: partitionData{number: 99}}}
+		if err := checkSourceFilesystems(d, resizes, false); err != nil {
+			t.Fatalf("checkSourceFilesystems: %v", err)
+		}
+		if e2fsckCalls != 1 {
+			t.Errorf("e2fsck call count = %d, want 1", e2fsckCalls)
+		}
+		if fatCalls != 0 {
+			t.Errorf("fsck.fat call count = %d, want 0", fatCalls)
+		}
+	})
+
+	t.Run("inconsistent ext4 source aborts the resize", func(t *testing.T) {
+		d, ext4, cleanup := openFixtureExt4(t)
+		defer cleanup()
+
+		origE := execE2fsck
+		defer func() { execE2fsck = origE }()
+		sentinel := errors.New("e2fsck failed: exit status 4")
+		execE2fsck = func(string, bool) error { return sentinel }
+
+		resizes := []partitionResizeTarget{{original: ext4, target: partitionData{number: 99}}}
+		err := checkSourceFilesystems(d, resizes, false)
+		if err == nil {
+			t.Fatal("expected error from an inconsistent source, got nil")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("returned error does not wrap the e2fsck error: %v", err)
+		}
+	})
+
+	t.Run("fat32 source is checked with fsck.fat", func(t *testing.T) {
+		d, src, cleanup := newFat32SourceDisk(t)
+		defer cleanup()
+
+		origE, origF := execE2fsck, execFsckFat
+		defer func() { execE2fsck, execFsckFat = origE, origF }()
+		var e2fsckCalls, fatCalls int
+		execE2fsck = func(string, bool) error { e2fsckCalls++; return nil }
+		execFsckFat = func(string, bool) error { fatCalls++; return nil }
+
+		resizes := []partitionResizeTarget{{original: src, target: partitionData{number: 99}}}
+		if err := checkSourceFilesystems(d, resizes, false); err != nil {
+			t.Fatalf("checkSourceFilesystems: %v", err)
+		}
+		if fatCalls != 1 {
+			t.Errorf("fsck.fat call count = %d, want 1", fatCalls)
+		}
+		if e2fsckCalls != 0 {
+			t.Errorf("e2fsck call count = %d, want 0", e2fsckCalls)
+		}
+	})
+
+	t.Run("squashfs source is skipped, not errored", func(t *testing.T) {
+		d, src, cleanup := newSquashfsSourceDisk(t)
+		defer cleanup()
+
+		origE, origF := execE2fsck, execFsckFat
+		defer func() { execE2fsck, execFsckFat = origE, origF }()
+		var e2fsckCalls, fatCalls int
+		execE2fsck = func(string, bool) error { e2fsckCalls++; return nil }
+		execFsckFat = func(string, bool) error { fatCalls++; return nil }
+
+		resizes := []partitionResizeTarget{{original: src, target: partitionData{number: 99}}}
+		if err := checkSourceFilesystems(d, resizes, false); err != nil {
+			t.Fatalf("checkSourceFilesystems should skip squashfs, got error: %v", err)
+		}
+		if e2fsckCalls != 0 || fatCalls != 0 {
+			t.Errorf("no checker should run for squashfs; e2fsck=%d fsck.fat=%d", e2fsckCalls, fatCalls)
+		}
+	})
+}
+
+// newFat32SourceDisk builds a disk image with a single FAT32 partition and
+// returns the open disk plus that partition's data.
+func newFat32SourceDisk(t *testing.T) (*disk.Disk, partitionData, func()) {
+	t.Helper()
+	const (
+		diskSize    int64 = 64 * MB
+		sectorSize        = 512
+		sourceStart       = 2048
+		sourceSize        = 16 * MB
+	)
+	diskPath := filepath.Join(t.TempDir(), "disk.img")
+	if err := os.WriteFile(diskPath, nil, 0o644); err != nil {
+		t.Fatalf("create disk: %v", err)
+	}
+	if err := os.Truncate(diskPath, diskSize); err != nil {
+		t.Fatalf("size disk: %v", err)
+	}
+	bk, err := file.OpenFromPath(diskPath, false)
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	d, err := diskfs.OpenBackend(bk, diskfs.WithOpenMode(diskfs.ReadWrite))
+	if err != nil {
+		_ = bk.Close()
+		t.Fatalf("open disk: %v", err)
+	}
+	table := &gpt.Table{
+		Partitions: []*gpt.Partition{
+			{Index: 1, Start: sourceStart, Size: sourceSize, Type: gpt.EFISystemPartition, Name: "source"},
+		},
+	}
+	if err := d.Partition(table); err != nil {
+		_ = bk.Close()
+		t.Fatalf("write partition table: %v", err)
+	}
+	if _, err := d.CreateFilesystem(disk.FilesystemSpec{Partition: 1, FSType: filesystem.TypeFat32, VolumeLabel: "source"}); err != nil {
+		_ = bk.Close()
+		t.Fatalf("CreateFilesystem(fat32): %v", err)
+	}
+	pd := partitionData{number: 1, start: sourceStart * sectorSize, size: sourceSize, label: "source"}
+	return d, pd, func() { _ = bk.Close() }
+}
+
+// newSquashfsSourceDisk builds a disk image with a single squashfs partition
+// and returns the open disk plus that partition's data.
+func newSquashfsSourceDisk(t *testing.T) (*disk.Disk, partitionData, func()) {
+	t.Helper()
+	const (
+		diskSize    int64 = 64 * MB
+		sectorSize        = 4096 // squashfs requires blocksize >= 4096
+		sourceStart       = 256
+		sourceSize        = 8 * MB
+	)
+	diskPath := filepath.Join(t.TempDir(), "disk.img")
+	if err := os.WriteFile(diskPath, nil, 0o644); err != nil {
+		t.Fatalf("create disk: %v", err)
+	}
+	if err := os.Truncate(diskPath, diskSize); err != nil {
+		t.Fatalf("size disk: %v", err)
+	}
+	// First pass: write the partition table.
+	bk, err := file.OpenFromPath(diskPath, false)
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	d, err := diskfs.OpenBackend(bk, diskfs.WithOpenMode(diskfs.ReadWrite), diskfs.WithSectorSize(sectorSize))
+	if err != nil {
+		_ = bk.Close()
+		t.Fatalf("open disk: %v", err)
+	}
+	table := &gpt.Table{
+		LogicalSectorSize:  sectorSize,
+		PhysicalSectorSize: sectorSize,
+		Partitions: []*gpt.Partition{
+			{Index: 1, Start: sourceStart, Size: sourceSize, Type: gpt.LinuxFilesystem, Name: "source"},
+		},
+	}
+	if err := d.Partition(table); err != nil {
+		_ = bk.Close()
+		t.Fatalf("write partition table: %v", err)
+	}
+	// Build a squashfs in the source partition and finalize it.
+	srcFS, err := d.CreateFilesystem(disk.FilesystemSpec{Partition: 1, FSType: filesystem.TypeSquashfs})
+	if err != nil {
+		_ = bk.Close()
+		t.Fatalf("CreateFilesystem(squashfs): %v", err)
+	}
+	sqs, ok := srcFS.(*squashfs.FileSystem)
+	if !ok {
+		_ = bk.Close()
+		t.Fatalf("source not *squashfs.FileSystem")
+	}
+	if err := sqs.Finalize(squashfs.FinalizeOptions{NoCompressInodes: true, NoCompressData: true, NoCompressFragments: true}); err != nil {
+		_ = bk.Close()
+		t.Fatalf("squashfs Finalize: %v", err)
+	}
+	_ = bk.Close()
+
+	// Reopen so the partition reads back as squashfs.
+	bk, err = file.OpenFromPath(diskPath, false)
+	if err != nil {
+		t.Fatalf("reopen backend: %v", err)
+	}
+	d, err = diskfs.OpenBackend(bk, diskfs.WithOpenMode(diskfs.ReadWrite), diskfs.WithSectorSize(sectorSize))
+	if err != nil {
+		_ = bk.Close()
+		t.Fatalf("reopen disk: %v", err)
+	}
+	if _, err := d.GetPartitionTable(); err != nil {
+		_ = bk.Close()
+		t.Fatalf("re-read partition table: %v", err)
+	}
+	pd := partitionData{number: 1, start: sourceStart * sectorSize, size: sourceSize, label: "source"}
+	return d, pd, func() { _ = bk.Close() }
+}

--- a/resize.go
+++ b/resize.go
@@ -345,6 +345,55 @@ func swapPartitions(d *disk.Disk, resizes []partitionResizeTarget) error {
 	return nil
 }
 
+// checkSourceFilesystems integrity-checks every source filesystem the resize
+// will read or modify, before any destructive step runs. ext4 sources are
+// checked with e2fsck and fat32 sources with fsck.fat; by default the checks
+// are read-only and an inconsistent filesystem aborts the resize, while
+// fixErrors upgrades them to repair. squashfs and other types have no
+// applicable checker and are copied as-is, so a corrupt squashfs source is
+// reproduced faithfully. This makes the integrity guarantee symmetric across
+// the shrink source and the grow sources, rather than only checking the shrink
+// partition that resize2fs would have checked anyway.
+func checkSourceFilesystems(d *disk.Disk, resizes []partitionResizeTarget, fixErrors bool) error {
+	device := d.Backend.Path()
+	if device == "" {
+		return fmt.Errorf("cannot check source filesystems: disk backend has no path")
+	}
+	checked := map[int]bool{}
+	for _, r := range resizes {
+		if checked[r.original.number] {
+			continue
+		}
+		checked[r.original.number] = true
+		fs, err := d.GetFilesystem(r.original.number)
+		if err != nil {
+			if isUnknownFilesystem(err) {
+				// no recognized filesystem (e.g. squashfs on a 512-byte
+				// sector disk, or raw data) -- nothing we can check
+				log.Printf("partition %d: no recognized filesystem, skipping integrity check", r.original.number)
+				continue
+			}
+			return fmt.Errorf("failed to get filesystem for source partition %d: %w", r.original.number, err)
+		}
+		var fsck func(string, bool) error
+		switch fs.Type() {
+		case filesystem.TypeExt4:
+			fsck = execE2fsck
+		case filesystem.TypeFat32:
+			fsck = execFsckFat
+		default:
+			// squashfs and other types have no applicable integrity check
+			log.Printf("partition %d: filesystem type %v has no integrity check, skipping", r.original.number, fs.Type())
+			continue
+		}
+		log.Printf("checking source filesystem on partition %d (%v)", r.original.number, fs.Type())
+		if err := checkFilesystem(device, r.original, fsck, fixErrors); err != nil {
+			return fmt.Errorf("integrity check failed for source partition %d: %w", r.original.number, err)
+		}
+	}
+	return nil
+}
+
 func shrinkFilesystems(d *disk.Disk, resizes []partitionResizeTarget, fixErrors bool) error {
 	for _, r := range resizes {
 		if r.original.size <= r.target.size {

--- a/run.go
+++ b/run.go
@@ -17,6 +17,20 @@ import (
 // error out if any filesystem errors are found. If fixErrors is true, it will attempt to fix any found errors.
 // If preserveNumbers is true, any partition that is relocated while growing is renumbered back to its original
 // partition number once the data has been copied, so its partition number (e.g. /dev/sda2) is unchanged by the resize.
+//
+// Pre-flight integrity checks. Before any destructive operation, Run
+// integrity-checks every source filesystem it will read or modify -- the shrink
+// partition and each grow source. ext4 sources are checked with e2fsck and
+// fat32 sources with fsck.fat; by default the checks are read-only and an
+// inconsistent filesystem aborts the resize, while fixErrors upgrades them to
+// repair (e2fsck -y / fsck.fat -a). squashfs sources (read-only,
+// content-addressed, copied raw) have no applicable check and are copied as-is,
+// so a corrupt squashfs source is reproduced faithfully. Run does NOT perform
+// usage-specific pre-flight checks such as free-space policy; that remains the
+// caller's responsibility. When resuming a previously-interrupted run, Run
+// reuses an already-written target only when it structurally matches its source
+// via CompareFS; that comparison is a structure/content equality check, not a
+// filesystem integrity check.
 func Run(disk string, shrinkPartition *PartitionIdentifier, growPartitions []PartitionChange, fixErrors, dryRun, preserveNumbers bool) error {
 	// we always work solely with partition UUIDs internally, so convert any other identifiers to UUIDs
 	// see if a disk was specified
@@ -75,6 +89,12 @@ func Run(disk string, shrinkPartition *PartitionIdentifier, growPartitions []Par
 	if dryRun {
 		log.Printf("Dry run specified, not performing resizes %+v", resizes)
 		return nil
+	}
+	// integrity-check the source filesystems before anything destructive, so a
+	// corrupt source aborts the resize rather than being shrunk in place or
+	// copied into a new partition
+	if err := checkSourceFilesystems(d, resizes, fixErrors); err != nil {
+		return err
 	}
 	log.Printf("Will perform resizes %+v", resizes)
 	return resize(d, resizes, fixErrors, preserveNumbers)

--- a/run_helpers.go
+++ b/run_helpers.go
@@ -1,8 +1,10 @@
 package partitionresizer
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -18,27 +20,59 @@ const (
 	partTmpFilename = "partresizer-shrinkfs-XXXXXXXX"
 )
 
-// execResize2fs is the function used to invoke resize2fs. partDevice may be a block device pointing to the actual
-// filesystem partition, or an image file with the filesystem at byte 0.
-var execResize2fs = func(partDevice string, newSizeMB int64, fixErrors bool) error {
+// runTool runs an external filesystem tool, streaming its output live to the
+// process's stdout/stderr while also capturing stderr. On a non-zero exit the
+// returned error wraps the exit status and includes the tool's own stderr
+// diagnostic, so a programmatic caller gets the reason for the failure rather
+// than a bare "exit status N".
+func runTool(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	var stderr bytes.Buffer
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			const max = 2000
+			if len(msg) > max {
+				msg = "..." + msg[len(msg)-max:]
+			}
+			return fmt.Errorf("%s failed: %w\n%s", name, err, msg)
+		}
+		return fmt.Errorf("%s failed: %w", name, err)
+	}
+	return nil
+}
+
+// execE2fsck runs a forced e2fsck on the given device or image file. By default
+// it is read-only (-n) and returns an error if the filesystem is inconsistent;
+// with fixErrors it repairs in place (-y).
+var execE2fsck = func(partDevice string, fixErrors bool) error {
 	fixFlag := "-n"
 	if fixErrors {
 		fixFlag = "-y"
 	}
-	cmd := exec.Command("e2fsck", "-f", fixFlag, partDevice)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("e2fsck failed: %w", err)
-	}
+	return runTool("e2fsck", "-f", fixFlag, partDevice)
+}
 
-	cmd = exec.Command("resize2fs", partDevice, fmt.Sprintf("%dM", newSizeMB))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("resize2fs failed: %w", err)
+// execFsckFat runs fsck.fat on the given device or image file. By default it is
+// read-only (-n) and returns an error if the filesystem is inconsistent; with
+// fixErrors it auto-repairs (-a).
+var execFsckFat = func(partDevice string, fixErrors bool) error {
+	fixFlag := "-n"
+	if fixErrors {
+		fixFlag = "-a"
 	}
-	return nil
+	return runTool("fsck.fat", fixFlag, partDevice)
+}
+
+// execResize2fs is the function used to invoke resize2fs. partDevice may be a block device pointing to the actual
+// filesystem partition, or an image file with the filesystem at byte 0. resize2fs requires a clean filesystem, so
+// e2fsck is always run first.
+var execResize2fs = func(partDevice string, newSizeMB int64, fixErrors bool) error {
+	if err := execE2fsck(partDevice, fixErrors); err != nil {
+		return err
+	}
+	return runTool("resize2fs", partDevice, fmt.Sprintf("%dM", newSizeMB))
 }
 
 // resizeFilesystem resizes an ext4 filesystem, given a full path to the device and partition data
@@ -100,6 +134,57 @@ func resizeFilesystem(
 		err = fmt.Errorf("unknown device type for %s", device)
 	}
 	return err
+}
+
+// checkFilesystem runs the given filesystem checker (e.g. execE2fsck,
+// execFsckFat) against the filesystem in the given partition. device is the
+// whole-disk device or image file; fsData describes the partition. The caller
+// selects fsck based on filesystem type; checkFilesystem only handles locating
+// the filesystem on the disk. The check is read-only unless fixErrors is set.
+// It mirrors resizeFilesystem's block-device-vs-image dispatch: for a block
+// device the partition's device node is checked directly; for an image file the
+// partition byte-range is extracted to a temp file, checked, and -- only when
+// repairing -- copied back.
+func checkFilesystem(device string, fsData partitionData, fsck func(string, bool) error, fixErrors bool) error {
+	f, err := os.Open(device)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	deviceType, err := disk.DetermineDeviceType(f)
+	if err != nil {
+		return err
+	}
+	switch deviceType {
+	case disk.DeviceTypeBlockDevice:
+		partDevice, err := partitionDevicePath(device, fsData.number, "")
+		if err != nil {
+			return fmt.Errorf("cannot find partition device for %s partition %d: %w", device, fsData.number, err)
+		}
+		return fsck(partDevice, fixErrors)
+	case disk.DeviceTypeFile:
+		tmpFile, err := os.CreateTemp("", partTmpFilename)
+		if err != nil {
+			return err
+		}
+		_ = tmpFile.Close()
+		defer func() { _ = os.RemoveAll(tmpFile.Name()) }()
+		if err := CopyRange(device, tmpFile.Name(), fsData.start, 0, fsData.size, 0); err != nil {
+			return fmt.Errorf("copy to temp file: %w", err)
+		}
+		if err := fsck(tmpFile.Name(), fixErrors); err != nil {
+			return err
+		}
+		// Only a repairing run mutates the filesystem; persist it back into
+		// the image. A read-only check leaves the source untouched.
+		if fixErrors {
+			return CopyRange(tmpFile.Name(), device, 0, fsData.start, fsData.size, 0)
+		}
+		return nil
+	case disk.DeviceTypeUnknown:
+		return fmt.Errorf("unknown device type for %s", device)
+	}
+	return nil
 }
 
 // planResizes computes the resize plan, including both growing the relevant partitions as well as


### PR DESCRIPTION
## What

Make source-filesystem integrity checking symmetric. Before any destructive
step, `Run` now checks every source filesystem it will read or modify — the
shrink partition **and** each grow source — not just the shrink partition.

Previously the only check was the `e2fsck` that `resize2fs` requires before
shrinking. Grow sources were copied unchecked, so a corrupt ext4 or FAT32
source was reproduced faithfully into the new partition (`CompareFS` verifies
source-vs-target structural equality, not integrity).

## How

- A pre-flight in `Run` walks the planned sources: ext4 → `e2fsck`, FAT32 →
  `fsck.fat`; read-only by default (`-n`) so an inconsistent filesystem aborts
  the resize, `fixErrors` upgrades to repair (`e2fsck -y` / `fsck.fat -a`).
  squashfs (raw-copied, content-addressed) has no applicable check and is
  skipped, not errored.
- `e2fsck` is factored out of `execResize2fs` into a shared `execE2fsck`, and a
  new `execFsckFat` added. A small `runTool` helper tees each tool's stderr to
  the process while capturing it, so a non-zero exit returns an error carrying
  the tool's own diagnostic instead of a bare `exit status N` — useful for
  programmatic callers.
- README gains a "Library use" section (import path, `Run` example, error and
  pre-flight behavior) and an **Options** section documenting the `<disk>`
  argument and all CLI flags. The `--fix-errors` flag help is also updated to
  reflect that it now repairs both ext4 and FAT32 sources (not just the shrink
  partition), and a `fsck.fat`/dosfstools dependency note is added.

## Tests

`preflight_test.go`: an ext4 source is `e2fsck`'d; an inconsistent ext4 source
aborts the preflight (the returned error wraps the e2fsck failure); a FAT32
source is `fsck.fat`'d; a squashfs source is skipped, not errored. The fsck
tools are mocked through the `execE2fsck`/`execFsckFat` vars (same pattern the
existing tests use for `execResize2fs`).

## Open question

The FAT32 preflight makes `fsck.fat` a hard dependency whenever a FAT32 source
is present — a missing binary fails the run. Should a missing checker instead
be a soft skip-with-warning? Happy to adjust.
