### PR TITLE
Re-pin go-diskfs to latest master, drop fork replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/diskfs/partitionresizer
 go 1.25.7
 
 require (
-	github.com/diskfs/go-diskfs v1.9.4-0.20260610103445-0e4e146f80a7
+	github.com/diskfs/go-diskfs v1.9.4-0.20260618163850-2bdff12e5d99
 	github.com/go-test/deep v1.1.1
 	github.com/spf13/cobra v1.10.2
 )
@@ -22,5 +22,3 @@ require (
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 )
-
-replace github.com/diskfs/go-diskfs => github.com/eriknordmark/go-diskfs v0.0.0-20260618133142-470c1e96eea8

--- a/go.sum
+++ b/go.sum
@@ -3,12 +3,12 @@ github.com/anchore/go-lzo v0.1.0/go.mod h1:3kLx0bve2oN1iDwgM1U5zGku1Tfbdb0No5qp1
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/diskfs/go-diskfs v1.9.4-0.20260618163850-2bdff12e5d99 h1:TQoAUPdUfe/S+CZo31LcLYtFgViuMyc7CbVyYmnFQ+k=
+github.com/diskfs/go-diskfs v1.9.4-0.20260618163850-2bdff12e5d99/go.mod h1:TePJORO83Adh5pb2SqsxAwaP0fofFxKLkxctiS/9OQc=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
 github.com/elliotwutingfeng/asciiset v0.0.0-20260129054604-cfde2086bc57 h1:x5yxNrq8XffV/OoNUeFPM6hxHVi5OTspSTBxr/9pemg=
 github.com/elliotwutingfeng/asciiset v0.0.0-20260129054604-cfde2086bc57/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
-github.com/eriknordmark/go-diskfs v0.0.0-20260618133142-470c1e96eea8 h1:z/avFLFoPxPdW8Mt7+nQLFComDj01sht6m3bbf/j5rk=
-github.com/eriknordmark/go-diskfs v0.0.0-20260618133142-470c1e96eea8/go.mod h1:TePJORO83Adh5pb2SqsxAwaP0fofFxKLkxctiS/9OQc=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
Bump `github.com/diskfs/go-diskfs` to the 2026-06-18 master tip, which now carries the `ErrReReadDeferred` change from diskfs/go-diskfs#411, and remove the temporary `replace github.com/diskfs/go-diskfs => github.com/eriknordmark/go-diskfs` directive. `go mod tidy` also prunes the stale `go.sum` entries left from the fork pin.

The replace was only ever meant to pin the pre-merge fork commit and be dropped once #411 landed in master. It was added in #15, where **Claude broke its own rule**: a temporary fork-pinning `replace` must be dropped before the PR merges, never carried into `main`. #15 merged with it still in tree, leaving upstream `main` depending on a personal fork; this PR removes it and re-pins to the real master tag.
