### PR TITLE
resizer: fix chaos grow to target the EFI System label

### DIFF
--- a/resume_stress_test.go
+++ b/resume_stress_test.go
@@ -277,7 +277,7 @@ func TestChaosKill(t *testing.T) {
 	shrinkArgs := []string{"--grow-partition", "label:P3:300M"} // Case 1: shrink P3 in place
 	growArgs := []string{                                       // Case 2: grow into the freed space
 		"--preserve-numbers",
-		"--grow-partition", "label:ESP:96M",
+		"--grow-partition", "label:EFI System:96M",
 		"--grow-partition", "label:IMGA:200M",
 		"--grow-partition", "label:IMGB:200M",
 	}


### PR DESCRIPTION
`TestChaosKill`'s grow phase targets partition label `ESP`, but the sample
fixture labels that partition `EFI System` (and the test's own assertions
key on `EFI System`). The grow therefore matches no partition and the
opt-in chaos test fails with "no disks found matching specified
partitions". This is a pre-existing mismatch; it only surfaces when the
chaos test's grow phase is actually run (`RESIZER_CHAOS=1` /
`CHAOS_GPT_DELAY`). Target the correct label.

One-line fix, independent of any feature work.
